### PR TITLE
Add TC58BVG0S3H and TC58NVG0S3H

### DIFF
--- a/release/linux/mtk/linux-4.4.198/drivers/mtd/nand/nand_ids.c
+++ b/release/linux/mtk/linux-4.4.198/drivers/mtd/nand/nand_ids.c
@@ -29,6 +29,14 @@ struct nand_flash_dev nand_flash_ids[] = {
 	 * listed by full ID. We list them first so that we can easily identify
 	 * the most specific match.
 	 */
+	{"TC58BVG0S3H 1G 3.3V 8-bit",
+		{ .id = {0x98, 0xf1, 0x80, 0x15, 0xf2, 0x16, 0x08, 0x00} },
+		  SZ_2K, SZ_128, SZ_128K, 0, 8, 64, NAND_ECC_INFO(1, SZ_512),
+		  2 }
+	{"TC58NVG0S3H 1G 3.3V 8-bit",
+		{ .id = {0x98, 0xf1, 0x80, 0x15, 0x72, 0x16, 0x08, 0x00} },
+		  SZ_2K, SZ_128, SZ_128K, 0, 8, 64, NAND_ECC_INFO(1, SZ_512),
+		  2 }
 	{"TC58NVG0S3E 1G 3.3V 8-bit",
 		{ .id = {0x98, 0xd1, 0x90, 0x15, 0x76, 0x14, 0x01, 0x00} },
 		  SZ_2K, SZ_128, SZ_128K, 0, 8, 64, NAND_ECC_INFO(1, SZ_512),


### PR DESCRIPTION
Maybe some information is wrong, I found it in other repositories on Github. And perhaps some more fixes are needed, because this memory (TC58BVG0S3H) has a guaranteed 1 bad block, about the second flash memory (TC58NVG0S3H), I did not search for information about bad blocks.